### PR TITLE
configure: fix tslib version check

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2561,7 +2561,7 @@ fi
 
 enable_tslib=no
 if test "$checkfor_tslib" = "yes"; then
-  PKG_CHECK_MODULES([TSLIB], [tslib-1.0 >= 1.0.0], [enable_tslib=yes], [enable_tslib=no])
+  PKG_CHECK_MODULES([TSLIB], [tslib-1.0 >= 1.0], [enable_tslib=yes], [enable_tslib=no])
   if test "$enable_tslib" = "no"; then
      PKG_CHECK_MODULES([TSLIB], [tslib-0.0], [enable_tslib=yes], [enable_tslib=no
        AC_MSG_WARN([*** no tslib -- tslib driver will not be built.])])


### PR DESCRIPTION
The tslib version is 1.0, not 1.0.0.  Trying to check for the latter
fails when using pkg-config:
$ pkg-config --exists --print-errors "tslib-1.0 >= 1.0"
$ pkg-config --exists --print-errors "tslib-1.0 >= 1.0.0"
Requested 'tslib-1.0 >= 1.0.0' but version of tslib is 1.0