### PR TITLE
configure: update tslib version check

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2563,7 +2563,7 @@ enable_tslib=no
 if test "$checkfor_tslib" = "yes"; then
   PKG_CHECK_MODULES([TSLIB], [tslib-1.0 >= 1.0], [enable_tslib=yes], [enable_tslib=no])
   if test "$enable_tslib" = "no"; then
-     PKG_CHECK_MODULES([TSLIB], [tslib-0.0], [enable_tslib=yes], [enable_tslib=no
+     PKG_CHECK_MODULES([TSLIB], [tslib], [enable_tslib=yes], [enable_tslib=no
        AC_MSG_WARN([*** no tslib -- tslib driver will not be built.])])
   fi
 fi


### PR DESCRIPTION
Since tslib 1.3 tslib's SONAME and pkg-config name and thus the ABI changed,
while the library is staying backwards compatible. The version number being
part of the name had been a mistake and is gone.

Since tslib-0 is well over 10 years old, we should not fall back to that
ancient version, but instead fall back to using a current version of tslib.

Signed-off-by: Martin Kepplinger <martin.kepplinger@ginzinger.com>