### PR TITLE
davinci: fix build with glibc >= 2.28

### DIFF
--- a/gfxdrivers/davinci/davinci_c64x.c
+++ b/gfxdrivers/davinci/davinci_c64x.c
@@ -39,6 +39,11 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+// Required for `makedev` in glibc >= 2.28
+#if defined(__GNU_LIBRARY__)
+#include <sys/sysmacros.h>
+#endif
+
 #include <directfb_util.h>
 
 #include <direct/clock.h>


### PR DESCRIPTION
From glibc 2.28 release notes:

* The macros 'major', 'minor', and 'makedev' are now only available from
  the header <sys/sysmacros.h>; not from <sys/types.h> or various other
  headers that happen to include <sys/types.h>.  These macros are rarely
  used, not part of POSIX nor XSI, and their names frequently collide with
  user code; see https://sourceware.org/bugzilla/show_bug.cgi?id=19239 for
  further explanation.

  <sys/sysmacros.h> is a GNU extension.  Portable programs that require
  these macros should first include <sys/types.h>, and then include
  <sys/sysmacros.h> if __GNU_LIBRARY__ is defined.

https://lists.gnu.org/archive/html/info-gnu/2018-08/msg00000.html