### PR TITLE
libdirect: remove use of keyword 'register'

### DIFF
--- a/lib/direct/util.h
+++ b/lib/direct/util.h
@@ -220,7 +220,7 @@ void DIRECT_API direct_md5_sum( void *dst, const void *src, const int len );
 static __inline__ int
 direct_util_count_bits( unsigned int mask )
 {
-     register int ret = 0;
+     int ret = 0;
 
      while (mask) {
           ret += mask & 1;
@@ -325,7 +325,7 @@ D_ICEIL(float f)
 static __inline__ int
 direct_log2( int val )
 {
-     register int ret = 0;
+     int ret = 0;
 
      while (val >> ++ret);
 


### PR DESCRIPTION
The 'register' keyword was removed in C++17 and is now unused and reserved. When compiling code that uses DirecthFB with C++17, compilation fails.

Since modern compilers likely don't produce different code whether the 'register' keyword is used or not, there shouldn't be any performance impact introduced by this change.