### PR TITLE
TaskManager: make timed_emits comparator const for GCC 16+

### DIFF
--- a/src/core/TaskManager.h
+++ b/src/core/TaskManager.h
@@ -121,7 +121,7 @@ public:
      static void       dumpTasks();
 
 
-     bool operator()( Task *t1, Task *t2 )
+     bool operator()( Task *t1, Task *t2 ) const
      {
           return t1->ts_emit < t2->ts_emit;
      }


### PR DESCRIPTION
Fixes #29.

The `TaskManager::operator()` used as the comparator for `std::set<Task*,TaskManager> timed_emits` was not `const`-qualified. GCC 16 / recent libstdc++ statically asserts that a container's comparator is invocable through a `const` reference, so the build fails with "comparison object must be invocable with arguments of key_type".

Adding `const` to `operator()` satisfies the requirement and does not change behaviour (the operator only reads `ts_emit`).